### PR TITLE
Fixed code smells related to missing default cases in switch statements

### DIFF
--- a/app/src/main/java/com/example/scoutconcordia/Activities/CalendarActivity.java
+++ b/app/src/main/java/com/example/scoutconcordia/Activities/CalendarActivity.java
@@ -113,13 +113,13 @@ public class CalendarActivity extends AppCompatActivity {
                         CalendarActivity.this.overridePendingTransition(0, 0);
                         break;
 
-                    case R.id.nav_schedule:
-                        break;
-
                     case R.id.nav_shuttle:
                         Intent shuttleIntent = new Intent(CalendarActivity.this, ShuttleScheduleActivity.class);
                         startActivity(shuttleIntent);
                         CalendarActivity.this.overridePendingTransition(0, 0);
+                        break;
+
+                    default:
                         break;
                 }
                 return false;
@@ -627,6 +627,9 @@ public class CalendarActivity extends AppCompatActivity {
                 startActivity(shuttleIntent);
                 CalendarActivity.this.overridePendingTransition(0, 0);
                 break;
+
+            default:
+                return super.onOptionsItemSelected(menuItem);
 
         }
         return false;

--- a/app/src/main/java/com/example/scoutconcordia/Activities/MapsActivity.java
+++ b/app/src/main/java/com/example/scoutconcordia/Activities/MapsActivity.java
@@ -196,8 +196,6 @@ public class MapsActivity extends AppCompatActivity implements OnMapReadyCallbac
             @Override
             public boolean onNavigationItemSelected(@NonNull MenuItem menuItem) {
                 switch (menuItem.getItemId()) {
-                    case R.id.nav_map:
-                        break;
 
                     case R.id.nav_schedule:
                         Intent calendarIntent = new Intent(MapsActivity.this, CalendarActivity.class);
@@ -210,6 +208,9 @@ public class MapsActivity extends AppCompatActivity implements OnMapReadyCallbac
                         Intent shuttleIntent = new Intent(MapsActivity.this, ShuttleScheduleActivity.class);
                         startActivity(shuttleIntent);
                         MapsActivity.this.overridePendingTransition(0, 0);
+                        break;
+
+                    default:
                         break;
                 }
                 return false;
@@ -1597,6 +1598,9 @@ public class MapsActivity extends AppCompatActivity implements OnMapReadyCallbac
                 startActivity(shuttleIntent);
                 MapsActivity.this.overridePendingTransition(0, 0);
                 break;
+
+            default:
+                return super.onOptionsItemSelected(menuItem);
 
         }
         return false;

--- a/app/src/main/java/com/example/scoutconcordia/Activities/SettingsActivity.java
+++ b/app/src/main/java/com/example/scoutconcordia/Activities/SettingsActivity.java
@@ -63,6 +63,9 @@ public class SettingsActivity extends AppCompatActivity {
                         startActivity(shuttleIntent);
                         SettingsActivity.this.overridePendingTransition(0, 0);
                         break;
+
+                    default:
+                        break;
                 }
                 return false;
             }
@@ -106,6 +109,9 @@ public class SettingsActivity extends AppCompatActivity {
                 startActivity(shuttleIntent);
                 SettingsActivity.this.overridePendingTransition(0, 0);
                 break;
+
+            default:
+                return super.onOptionsItemSelected(menuItem);
 
         }
         return false;

--- a/app/src/main/java/com/example/scoutconcordia/Activities/ShuttleScheduleActivity.java
+++ b/app/src/main/java/com/example/scoutconcordia/Activities/ShuttleScheduleActivity.java
@@ -45,7 +45,7 @@ public class ShuttleScheduleActivity extends AppCompatActivity {
                         ShuttleScheduleActivity.this.overridePendingTransition(0, 0);
                         break;
 
-                    case R.id.nav_shuttle:
+                    default:
                         break;
                 }
                 return false;
@@ -91,6 +91,10 @@ public class ShuttleScheduleActivity extends AppCompatActivity {
                 startActivity(settingsIntent);
                 ShuttleScheduleActivity.this.overridePendingTransition(0,0);
                 break;
+
+            default:
+            return super.onOptionsItemSelected(menuItem);
+
         }
         return false;
     }


### PR DESCRIPTION
Related to issue #251 
Added default cases to switch statements of methods handling menu clicks for both the overflow menu and the bottom navigation pane. 
Methods handling the clicks:
- onOptionsItemSelected()
- onNavigationItemSelected()