### PR TITLE
Bug fix directions

### DIFF
--- a/app/src/main/java/com/example/scoutconcordia/Activities/MapsActivity.java
+++ b/app/src/main/java/com/example/scoutconcordia/Activities/MapsActivity.java
@@ -1419,6 +1419,7 @@ public class MapsActivity extends AppCompatActivity implements OnMapReadyCallbac
         mMap.setInfoWindowAdapter(adapter);
         initializeSearchBar();
         searchPath = mMap.addPolyline(new PolylineOptions());
+        searchMarker = mMap.addMarker(new MarkerOptions().position(concordiaLatLngDowntownCampus).visible(false));
     }
 
     // moves the camera to keep on user's location on any change in its location


### PR DESCRIPTION
## **Identification**
**ID**: D-19
**Name**: Program crashes when getting directions if the searchMarker is never specified.
**Related to issue**: #27
**Reported by**: Vincent Cerri
**Submitted**: 2020-04-15
## **Environment**
**Device**: Pixel 3
**API Version**: API 29
## **Details**
**Summary**: There is a variable called searchMarker in the MapsActivity class. This marker holds the data for the marker that is to be search for when getting directions. The marker gets updated when clicking on different buildings.
**Steps to reproduce**: 
1. Open the application
2. Click the search bar and type an indoor location e.g H-205
3. Search for a destination e.g H-110
**Expected results**: Directions should be displayed from the starting location to the destination. 
**Actual results**: Crash
## **Severity**
**Severity**: Major 
**Priority**: Medium



**Solution:**
To solve this bug, the searchMarker needed to be initialized in the onMapReady method of the mapsActivity class. The bug was specially happening only if you go directly to searching without clicking on anything else when opening the application.