### PR TITLE
Accessiblity settings

### DIFF
--- a/app/src/main/java/com/example/scoutconcordia/Activities/MapsActivity.java
+++ b/app/src/main/java/com/example/scoutconcordia/Activities/MapsActivity.java
@@ -187,7 +187,7 @@ public class MapsActivity extends AppCompatActivity implements OnMapReadyCallbac
     private BottomNavigationView travelOptionsMenu = null;
     private boolean shuttleAvailable = false;
 
-    private boolean disabilityPreference = false; //false for no disability, true for disability
+    private boolean disabilityPreference = SettingsFragment.getDisabilityPreference(); //false for no disability, true for disability
     private boolean needMoreDirections = false; //this boolean will be used when getting directions from class to class in another building
     private boolean classToClass = false; //this boolean determines if we are searching from a class in 1 building to a class in another building
     private boolean classesInDifBuildings = false; //this boolean determines if the 2 classes are in the same building or different buildings.
@@ -317,7 +317,7 @@ public class MapsActivity extends AppCompatActivity implements OnMapReadyCallbac
         else {
             // we have to get more creative with the search and break it down
             // we need to search from class -> escalator, then from escalator -> class on the right floor
-            if (disabilityPreference)
+            if (SettingsFragment.getDisabilityPreference())
             {
                 nextStep.setVisibility(VISIBLE); // enable the next step button
                 Object[] path1 = graph1.breathFirstSearch(point1, graph1.searchByClassName("ELEVATOR"));

--- a/app/src/main/java/com/example/scoutconcordia/Activities/MapsActivity.java
+++ b/app/src/main/java/com/example/scoutconcordia/Activities/MapsActivity.java
@@ -192,7 +192,7 @@ public class MapsActivity extends AppCompatActivity implements OnMapReadyCallbac
     private BottomNavigationView travelOptionsMenu = null;
     private boolean shuttleAvailable = false;
 
-    boolean disabilityPreference = SettingsFragment.getDisabilityPreference(); //false for no disability, true for disability
+    boolean disabilityPreference; //false for no disability, true for disability
     private boolean needMoreDirections = false; //this boolean will be used when getting directions from class to class in another building
     private boolean classToClass = false; //this boolean determines if we are searching from a class in 1 building to a class in another building
     private boolean classesInDifBuildings = false; //this boolean determines if the 2 classes are in the same building or different buildings.
@@ -323,6 +323,7 @@ public class MapsActivity extends AppCompatActivity implements OnMapReadyCallbac
         else {
             // we have to get more creative with the search and break it down
             // we need to search from class -> escalator, then from escalator -> class on the right floor
+            disabilityPreference = SettingsFragment.getDisabilityPreference();
             if (disabilityPreference)
             {
                 nextStep.setVisibility(VISIBLE); // enable the next step button

--- a/app/src/main/java/com/example/scoutconcordia/Activities/MapsActivity.java
+++ b/app/src/main/java/com/example/scoutconcordia/Activities/MapsActivity.java
@@ -6,11 +6,13 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
+import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 
 import android.app.AlertDialog;
 import android.annotation.SuppressLint;
 import android.app.Dialog;
+import android.app.FragmentTransaction;
 import android.content.Context;
 import android.content.res.Resources;
 import android.graphics.Bitmap;
@@ -190,7 +192,7 @@ public class MapsActivity extends AppCompatActivity implements OnMapReadyCallbac
     private BottomNavigationView travelOptionsMenu = null;
     private boolean shuttleAvailable = false;
 
-    private boolean disabilityPreference = SettingsFragment.getDisabilityPreference(); //false for no disability, true for disability
+    boolean disabilityPreference = SettingsFragment.getDisabilityPreference(); //false for no disability, true for disability
     private boolean needMoreDirections = false; //this boolean will be used when getting directions from class to class in another building
     private boolean classToClass = false; //this boolean determines if we are searching from a class in 1 building to a class in another building
     private boolean classesInDifBuildings = false; //this boolean determines if the 2 classes are in the same building or different buildings.
@@ -198,13 +200,12 @@ public class MapsActivity extends AppCompatActivity implements OnMapReadyCallbac
     private TextView travelTime;  //estimated travel time
     private TextView from;    //outdoor building start point
     private TextView to;      //outdoor building destination
-    private Button buttonToCheckAccess; //verifies accessibility state matches switch
+
     // Displays the Map
     @Override protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_maps);
         setmContext(this);
-
 
         //Toolbar on top of the page
         Toolbar myToolbar = (Toolbar) findViewById(R.id.my_toolbar);

--- a/app/src/main/java/com/example/scoutconcordia/Activities/MapsActivity.java
+++ b/app/src/main/java/com/example/scoutconcordia/Activities/MapsActivity.java
@@ -1,6 +1,7 @@
 package com.example.scoutconcordia.Activities;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 import androidx.core.app.ActivityCompat;
@@ -19,6 +20,7 @@ import android.graphics.Color;
 import android.Manifest;
 import android.content.pm.PackageManager;
 import android.location.Location;
+import android.os.Build;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.LayoutInflater;
@@ -111,6 +113,7 @@ import static android.content.ContentValues.TAG;
 import static android.view.View.GONE;
 import static android.view.View.VISIBLE;
 
+@RequiresApi(api = Build.VERSION_CODES.M)
 public class MapsActivity extends AppCompatActivity implements OnMapReadyCallback, GoogleMap.OnMyLocationChangeListener, GoogleMap.OnCameraMoveStartedListener, GoogleMap.OnMyLocationButtonClickListener{
 
     private GoogleMap mMap;
@@ -195,12 +198,13 @@ public class MapsActivity extends AppCompatActivity implements OnMapReadyCallbac
     private TextView travelTime;  //estimated travel time
     private TextView from;    //outdoor building start point
     private TextView to;      //outdoor building destination
-
+    private Button buttonToCheckAccess; //verifies accessibility state matches switch
     // Displays the Map
     @Override protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_maps);
         setmContext(this);
+
 
         //Toolbar on top of the page
         Toolbar myToolbar = (Toolbar) findViewById(R.id.my_toolbar);
@@ -267,6 +271,7 @@ public class MapsActivity extends AppCompatActivity implements OnMapReadyCallbac
 
     }
 
+
     public List<Object[]> searchForClass(String fromMe, String toMe) {
         // if we dont find the to me location on the same floor we need to send it to the escalator.
         LatLng point1 = null;
@@ -317,7 +322,7 @@ public class MapsActivity extends AppCompatActivity implements OnMapReadyCallbac
         else {
             // we have to get more creative with the search and break it down
             // we need to search from class -> escalator, then from escalator -> class on the right floor
-            if (SettingsFragment.getDisabilityPreference())
+            if (disabilityPreference)
             {
                 nextStep.setVisibility(VISIBLE); // enable the next step button
                 Object[] path1 = graph1.breathFirstSearch(point1, graph1.searchByClassName("ELEVATOR"));
@@ -781,6 +786,7 @@ public class MapsActivity extends AppCompatActivity implements OnMapReadyCallbac
             }
         });
     }
+
 
     private void initializeSearchBar(){
         final AutoCompleteTextView searchBar = findViewById(R.id.search_bar);

--- a/app/src/main/java/com/example/scoutconcordia/Activities/SettingsActivity.java
+++ b/app/src/main/java/com/example/scoutconcordia/Activities/SettingsActivity.java
@@ -4,8 +4,11 @@ import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 
+import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.preference.PreferenceManager;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
@@ -18,7 +21,6 @@ import com.google.android.material.bottomnavigation.BottomNavigationView;
 import com.google.api.services.calendar.model.Setting;
 
 public class SettingsActivity extends AppCompatActivity {
-
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {

--- a/app/src/main/java/com/example/scoutconcordia/Activities/SettingsFragment.java
+++ b/app/src/main/java/com/example/scoutconcordia/Activities/SettingsFragment.java
@@ -23,31 +23,30 @@ import javax.annotation.Nullable;
 @RequiresApi(api = Build.VERSION_CODES.M)
 public class SettingsFragment extends PreferenceFragment  {
 
-    public static final String PREF_ACCESSIBILITY = "accessibility_settings";
-    private static boolean disabilityPreferences = false;
-    private SharedPreferences.OnSharedPreferenceChangeListener preferenceChangeListener;
-    Context context = getContext();
+    private static boolean disabilityPreferences = false;//static variable that will be used in the MapsActivity for accessibility settings
     private Context mContext;
     private Activity mActivity;
 
 
-    // SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences (context);
-    //SharedPreferences settings = PreferenceManager.getDefaultSharedPreferences(context);
-
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState){
         super.onCreate(savedInstanceState);
-
+        //display preferences
         addPreferencesFromResource(R.xml.preferences);
 
+        //get application context
         mContext = this.getActivity();
         mActivity = this.getActivity();
 
+        /**
+         * SwitchPreference stores the boolean in the SharedPreferences
+         * This ensures that the state of the switch is saved when the app is restarted.
+         */
         final SwitchPreference accessibility = (SwitchPreference) findPreference(this.getResources()
                 .getString(R.string.AccessibilitySettings));
 
 
-        /*
+        /**
             void setOnPreferenceChangeListener (Preference.OnPreferenceChangeListener onPreferenceChangeListener)
                 Sets the callback to be invoked when this Preference is changed by the user
                 (but before the internal state has been updated).
@@ -61,80 +60,32 @@ public class SettingsFragment extends PreferenceFragment  {
             @Override
             public boolean onPreferenceChange(Preference preference, Object o) {
                 if(accessibility.isChecked()){
-                    Toast.makeText(mActivity,"Unchecked",Toast.LENGTH_SHORT).show();
+                    //Display state of the switch
+                   Toast.makeText(mActivity,"Unchecked",Toast.LENGTH_SHORT).show();
 
                     // Checked the switch programmatically
                     accessibility.setChecked(false);
+                    disabilityPreferences = false; //accessibility settings not needed
+
+
                 }else {
                     Toast.makeText(mActivity,"Checked",Toast.LENGTH_SHORT).show();
 
                     // Unchecked the switch programmatically
                     accessibility.setChecked(true);
+                    disabilityPreferences = true; //user wants accessibility settings on
+
                 }
                 return false;
             }
         });
 
-//        preferenceChangeListener = new SharedPreferences.OnSharedPreferenceChangeListener()
-//        {
-//            @Override
-//            public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key)
-//            {
-//                if(key.equals(PREF_ACCESSIBILITY))
-//                {
-//
-//
-//                    //   accessibilityPreference.getSharedPreferences();
-//                    SwitchPreference accessibilityPreference = (SwitchPreference)findPreference(key);
-//
-//                    if(accessibilityPreference.isEnabled()){
-//                        accessibilityPreference.setSummaryOn("SWITCH");
-//                        disabilityPreferences = true;
-//
-//                    } else if (!accessibilityPreference.isEnabled()){
-//                        accessibilityPreference.setSummaryOff("SWITCH IS OFF");
-//                        disabilityPreferences = false;
-//                    }
-//
-//
-//
-//                }
-//            }
-//        };
-
     }
 
+    //Getter method to access the user's choice from the MapsActivity
     public static boolean getDisabilityPreference(){
         return disabilityPreferences;
     }
-
-    @Override
-    public void onResume()
-    {
-        super.onResume();
-
-       // getPreferenceScreen().getSharedPreferences().registerOnSharedPreferenceChangeListener(preferenceChangeListener);
-//        SwitchPreference accessibilityPreference = (SwitchPreference)findPreference(PREF_ACCESSIBILITY);
-//
-//        if(accessibilityPreference.isEnabled()){
-//            accessibilityPreference.setSummaryOn("SWITCH");
-//            disabilityPreferences = true;
-//
-//        } else {
-//            accessibilityPreference.setSummaryOff("SWITCH IS OFF");
-//            disabilityPreferences = false;
-//        }
-
-    }
-
-    @Override
-    public void onPause()
-    {
-        super.onPause();
-    //    getPreferenceScreen().getSharedPreferences().unregisterOnSharedPreferenceChangeListener(preferenceChangeListener);
-    }
-
-
 
 }
 

--- a/app/src/main/java/com/example/scoutconcordia/Activities/SettingsFragment.java
+++ b/app/src/main/java/com/example/scoutconcordia/Activities/SettingsFragment.java
@@ -67,7 +67,7 @@ public class SettingsFragment extends PreferenceFragment  {
                     // Checked the switch programmatically
                     accessibility.setChecked(false);
                     disabilityPreferences = false; //accessibility settings not needed
-                    Toast.makeText(mActivity,"Disability Preference variable value:" +disabilityPreferences,Toast.LENGTH_SHORT).show();
+                    Toast.makeText(mActivity,"Accessibility settings are turned off" ,Toast.LENGTH_SHORT).show();
 
 
                 }else {
@@ -75,7 +75,7 @@ public class SettingsFragment extends PreferenceFragment  {
                     // Unchecked the switch programmatically
                     accessibility.setChecked(true);
                     disabilityPreferences = true; //user wants accessibility settings on
-                    Toast.makeText(mActivity,"Disability preference variable value: " + disabilityPreferences,Toast.LENGTH_SHORT).show();
+                    Toast.makeText(mActivity,"Accessibility settings are now on" ,Toast.LENGTH_SHORT).show();
 
                 }
                 return false;

--- a/app/src/main/java/com/example/scoutconcordia/Activities/SettingsFragment.java
+++ b/app/src/main/java/com/example/scoutconcordia/Activities/SettingsFragment.java
@@ -81,7 +81,10 @@ public class SettingsFragment extends PreferenceFragment  {
                 return false;
             }
         });
+    }
 
+    static public Boolean getDisabilityPreference() {
+        return disabilityPreferences;
     }
 
 

--- a/app/src/main/java/com/example/scoutconcordia/Activities/SettingsFragment.java
+++ b/app/src/main/java/com/example/scoutconcordia/Activities/SettingsFragment.java
@@ -9,6 +9,10 @@ import android.preference.Preference;
 import android.preference.PreferenceFragment;
 import android.preference.PreferenceManager;
 import android.preference.SwitchPreference;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
 import android.widget.Switch;
 import android.widget.Toast;
 
@@ -60,20 +64,18 @@ public class SettingsFragment extends PreferenceFragment  {
             @Override
             public boolean onPreferenceChange(Preference preference, Object o) {
                 if(accessibility.isChecked()){
-                    //Display state of the switch
-                   Toast.makeText(mActivity,"Unchecked",Toast.LENGTH_SHORT).show();
-
                     // Checked the switch programmatically
                     accessibility.setChecked(false);
                     disabilityPreferences = false; //accessibility settings not needed
+                    Toast.makeText(mActivity,"Disability Preference variable value:" +disabilityPreferences,Toast.LENGTH_SHORT).show();
 
 
                 }else {
-                    Toast.makeText(mActivity,"Checked",Toast.LENGTH_SHORT).show();
 
                     // Unchecked the switch programmatically
                     accessibility.setChecked(true);
                     disabilityPreferences = true; //user wants accessibility settings on
+                    Toast.makeText(mActivity,"Disability preference variable value: " + disabilityPreferences,Toast.LENGTH_SHORT).show();
 
                 }
                 return false;
@@ -82,10 +84,6 @@ public class SettingsFragment extends PreferenceFragment  {
 
     }
 
-    //Getter method to access the user's choice from the MapsActivity
-    public static boolean getDisabilityPreference(){
-        return disabilityPreferences;
-    }
 
 }
 

--- a/app/src/main/java/com/example/scoutconcordia/Activities/SettingsFragment.java
+++ b/app/src/main/java/com/example/scoutconcordia/Activities/SettingsFragment.java
@@ -1,19 +1,140 @@
 package com.example.scoutconcordia.Activities;
 
+import android.app.Activity;
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.os.Build;
 import android.os.Bundle;
+import android.preference.Preference;
 import android.preference.PreferenceFragment;
+import android.preference.PreferenceManager;
+import android.preference.SwitchPreference;
+import android.widget.Switch;
+import android.widget.Toast;
+
+import androidx.annotation.RequiresApi;
 
 import com.example.scoutconcordia.R;
 
+import java.util.prefs.PreferenceChangeListener;
+
 import javax.annotation.Nullable;
 
-public class SettingsFragment extends PreferenceFragment {
+@RequiresApi(api = Build.VERSION_CODES.M)
+public class SettingsFragment extends PreferenceFragment  {
+
+    public static final String PREF_ACCESSIBILITY = "accessibility_settings";
+    private static boolean disabilityPreferences = false;
+    private SharedPreferences.OnSharedPreferenceChangeListener preferenceChangeListener;
+    Context context = getContext();
+    private Context mContext;
+    private Activity mActivity;
+
+
+    // SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences (context);
+    //SharedPreferences settings = PreferenceManager.getDefaultSharedPreferences(context);
 
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState){
         super.onCreate(savedInstanceState);
 
         addPreferencesFromResource(R.xml.preferences);
+
+        mContext = this.getActivity();
+        mActivity = this.getActivity();
+
+        final SwitchPreference accessibility = (SwitchPreference) findPreference(this.getResources()
+                .getString(R.string.AccessibilitySettings));
+
+
+        /*
+            void setOnPreferenceChangeListener (Preference.OnPreferenceChangeListener onPreferenceChangeListener)
+                Sets the callback to be invoked when this Preference is changed by the user
+                (but before the internal state has been updated).
+
+            Parameters
+                onPreferenceChangeListener Preference.OnPreferenceChangeListener: The callback to be invoked.
+        */
+
+        // SwitchPreference preference change listener
+        accessibility.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+            @Override
+            public boolean onPreferenceChange(Preference preference, Object o) {
+                if(accessibility.isChecked()){
+                    Toast.makeText(mActivity,"Unchecked",Toast.LENGTH_SHORT).show();
+
+                    // Checked the switch programmatically
+                    accessibility.setChecked(false);
+                }else {
+                    Toast.makeText(mActivity,"Checked",Toast.LENGTH_SHORT).show();
+
+                    // Unchecked the switch programmatically
+                    accessibility.setChecked(true);
+                }
+                return false;
+            }
+        });
+
+//        preferenceChangeListener = new SharedPreferences.OnSharedPreferenceChangeListener()
+//        {
+//            @Override
+//            public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key)
+//            {
+//                if(key.equals(PREF_ACCESSIBILITY))
+//                {
+//
+//
+//                    //   accessibilityPreference.getSharedPreferences();
+//                    SwitchPreference accessibilityPreference = (SwitchPreference)findPreference(key);
+//
+//                    if(accessibilityPreference.isEnabled()){
+//                        accessibilityPreference.setSummaryOn("SWITCH");
+//                        disabilityPreferences = true;
+//
+//                    } else if (!accessibilityPreference.isEnabled()){
+//                        accessibilityPreference.setSummaryOff("SWITCH IS OFF");
+//                        disabilityPreferences = false;
+//                    }
+//
+//
+//
+//                }
+//            }
+//        };
+
     }
 
+    public static boolean getDisabilityPreference(){
+        return disabilityPreferences;
+    }
+
+    @Override
+    public void onResume()
+    {
+        super.onResume();
+
+       // getPreferenceScreen().getSharedPreferences().registerOnSharedPreferenceChangeListener(preferenceChangeListener);
+//        SwitchPreference accessibilityPreference = (SwitchPreference)findPreference(PREF_ACCESSIBILITY);
+//
+//        if(accessibilityPreference.isEnabled()){
+//            accessibilityPreference.setSummaryOn("SWITCH");
+//            disabilityPreferences = true;
+//
+//        } else {
+//            accessibilityPreference.setSummaryOff("SWITCH IS OFF");
+//            disabilityPreferences = false;
+//        }
+
+    }
+
+    @Override
+    public void onPause()
+    {
+        super.onPause();
+    //    getPreferenceScreen().getSharedPreferences().unregisterOnSharedPreferenceChangeListener(preferenceChangeListener);
+    }
+
+
+
 }
+

--- a/app/src/main/res/layout/activity_maps.xml
+++ b/app/src/main/res/layout/activity_maps.xml
@@ -78,33 +78,6 @@
         android:checked="true"
         android:layout_centerInParent="true" />
 
-    <Button
-        android:layout_width="75dp"
-        android:layout_height="35dp"
-        android:text="test accessibility"
-        android:id="@+id/buttonToCheck"
-        android:layout_below="@id/search"
-        />
-
-
-    <!--We are keeping this in case we need it for the Google Search bar later  -->
-    <!--<Button
-        android:id="@+id/findYouWayButton"
-        android:layout_width="wrap_content"
-        android:layout_height="30dp"
-        android:paddingHorizontal="10dp"
-        android:text="@string/find_your_way_button"
-        android:textOff="@string/toggle_off"
-        android:textOn="@string/toggle_on"
-        android:layout_below="@id/toggleButton"
-        android:background="@drawable/shadow_toggle"
-        android:textColor="@color/white"
-        android:textFontWeight="500"
-        android:layout_centerInParent="true"
-        android:onClick="onFindYourWayButtonClick"
-        />
--->
-
     <com.google.android.material.bottomappbar.BottomAppBar
         android:id="@+id/bottomAppBar"
         style="@style/Widget.MaterialComponents.BottomAppBar.Colored"

--- a/app/src/main/res/layout/activity_maps.xml
+++ b/app/src/main/res/layout/activity_maps.xml
@@ -78,6 +78,15 @@
         android:checked="true"
         android:layout_centerInParent="true" />
 
+    <Button
+        android:layout_width="75dp"
+        android:layout_height="35dp"
+        android:text="test accessibility"
+        android:id="@+id/buttonToCheck"
+        android:layout_below="@id/search"
+        />
+
+
     <!--We are keeping this in case we need it for the Google Search bar later  -->
     <!--<Button
         android:id="@+id/findYouWayButton"

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -3,7 +3,8 @@
 
 
     <SwitchPreference
-        android:key="accessibility_settings"
+        android:key="@string/AccessibilitySettings"
+        android:defaultValue="false"
         android:title="@string/AccessibilitySettings"
         android:summary="@string/summary"/>
 


### PR DESCRIPTION
Accessibility settings can now be set through the settings menu of the application by using the switch. When the switch is set to true, the user is told to take the elevators instead of the escalators. 
Related to issue #241 

![image](https://user-images.githubusercontent.com/26283932/79642372-10b4f580-816b-11ea-905b-8da9b30b14d5.png)
![image](https://user-images.githubusercontent.com/26283932/79642388-25918900-816b-11ea-8ffe-c82487fd47ec.png)
